### PR TITLE
Fix Server Name Prefix Bug.

### DIFF
--- a/conf/templates/web/servers/app.conf
+++ b/conf/templates/web/servers/app.conf
@@ -110,7 +110,7 @@ server {
 		{{if $domain.SSL.IsEnabled -}}
 server {
 	listen 443 ssl;
-	server_name {{if eq $domain.WWW "drop"}}www.{{$domain.FQDN}}{{end}};
+	server_name {{if eq $domain.WWW "drop"}}www.{{end}}{{$domain.FQDN}};
 
 	include {{$.WebConfigPath}}/includes/ssl.conf;
 	ssl_certificate {{$domain.SSL.Certificate}};


### PR DESCRIPTION
We figured, that hoi serves malicious config for nginx in case you setup a server name with www and ssl in combinition. Found a bug app.conf messing up an if-statement.