### PR TITLE
Add locking/unlocking of systems during reloads; implements #14.

### DIFF
--- a/system/nginx.go
+++ b/system/nginx.go
@@ -59,8 +59,13 @@ func (sys *NGINX) Reload() error {
 	NGINXLock.Lock()
 	defer NGINXLock.Unlock()
 
-	if _, err := sys.conn.ReloadUnit("nginx", "replace", nil); err != nil {
+	done := make(chan string)
+
+	if _, err := sys.conn.ReloadUnit("nginx", "replace", done); err != nil {
 		return fmt.Errorf("failed to reload NGINX; possibly left in dirty state: %s", err)
+	}
+	if r := <-done; r != "done" {
+		return fmt.Errorf("failed to reload NGINX; systemd job states: %s", r)
 	}
 	NGINXDirty = false
 	return nil
@@ -73,8 +78,13 @@ func (sys *NGINX) ReloadIfDirty() error {
 	NGINXLock.Lock()
 	defer NGINXLock.Unlock()
 
-	if _, err := sys.conn.ReloadUnit("nginx", "replace", nil); err != nil {
+	done := make(chan string)
+
+	if _, err := sys.conn.ReloadUnit("nginx", "replace", done); err != nil {
 		return fmt.Errorf("failed to reload NGINX; left in dirty state: %s", err)
+	}
+	if r := <-done; r != "done" {
+		return fmt.Errorf("failed to reload NGINX; systemd job states: %s", r)
 	}
 	NGINXDirty = false
 	return nil

--- a/system/php.go
+++ b/system/php.go
@@ -58,8 +58,13 @@ func (sys PHP) ReloadIfDirty() error {
 	PHPLock.Lock()
 	defer PHPLock.Unlock()
 
-	if _, err := sys.conn.ReloadUnit("php5-fpm", "replace", nil); err != nil {
+	done := make(chan string)
+
+	if _, err := sys.conn.ReloadUnit("php5-fpm", "replace", done); err != nil {
 		return fmt.Errorf("failed to reload PHP; left in dirty state: %s", err)
+	}
+	if r := <-done; r != "done" {
+		return fmt.Errorf("failed to reload PHP; systemd job states: %s", r)
 	}
 	PHPDirty = false
 	return nil


### PR DESCRIPTION
This implements the [receiver channel blocking idiom](https://golang.org/doc/effective_go.html#channels) for [ReloadUnit](https://godoc.org/github.com/coreos/go-systemd/dbus#Conn.ReloadUnit) calls in Hoi systems nginx ([1](https://github.com/atelierdisko/hoi/blob/master/system/nginx.go#L62), [2](https://github.com/atelierdisko/hoi/blob/master/system/nginx.go#L76)) and php ([1](https://github.com/atelierdisko/hoi/blob/master/system/php.go#L61)). In golang, receivers always block until there is data to receive. Using it to make sure Reload methods unlock not before the systemd operation finishes with a message piped into the channel. ~~Message is discarded though, could be anything.~~ Please review. Thanks! :)